### PR TITLE
Persist profile skip locks across config resets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Smoke tests
+
+Для проверки profile lock логики перед PR запустите:
+
+```bash
+bash tests/profile_lock_smoke.sh
+```
+
+Тест работает только с временной директорией в `/tmp`:
+
+- не пишет в `/opt`;
+- не запускает и не останавливает `zapret2`;
+- проверяет `bash -n` для основных shell-файлов;
+- проверяет `profile.lock` storage: `auto` как отсутствие записи, `skip`, `N`, `clear`;
+- проверяет idempotent `profile_apply_all`;
+- проверяет `YT_UDP`, `YT_TCP`, `RKN`, `VOICE_UDP`;
+- проверяет, что TCP hostlist-правки не затрагивают отдельную Discord TCP-строку;
+- проверяет, что некорректный stale lock вроде `YT_UDP 99` не роняет apply.
+
+Успешный результат:
+
+```text
+profile_lock smoke ok
+```

--- a/lib/actions.sh
+++ b/lib/actions.sh
@@ -55,6 +55,7 @@ menu_action_update_config_reset() {
   change_user
 
   cp -f /opt/zapret2/config.default /opt/zapret2/config
+  profile_apply_all /opt/zapret2/config
 
   "$ZAPRET2_INIT" start
 
@@ -67,20 +68,20 @@ menu_action_update_config_reset() {
 }
 
 menu_action_toggle_bolvan_ports() {
-  if grep -Eq '^NFQWS_PORTS_UDP=.*443$' "/opt/zapret2/config"; then
-    sed -i '76s/443$/443,1400,3478-3481,5349,50000-50099,19294-19344/' /opt/zapret2/config
-    sed -i 's/^--skip --filter-udp=50000/--filter-udp=50000/' "/opt/zapret2/config"
+  local cfg="/opt/zapret2/config"
+  local voice_ports="50000-50099,1400,3478-3481,5349,19294-19344"
+  local init_dir custom_dir
 
-    init_dir="$(dirname "$ZAPRET2_INIT")"
-    custom_dir="$init_dir/custom.d"
-    rm -f "$custom_dir/50-discord-media" \
-          "$custom_dir/50-stun4all"
+  if ! grep -Eq '^NFQWS2_PORTS_UDP=.*50000-50099' "$cfg"; then
+    profile_lock_clear "VOICE_UDP"
+    profile_apply_voice_classic "$cfg"
 
     echo -e "${green}Уход от скриптов bol-van. Выделены порты 50000-50099,1400,3478-3481,5349 и раскомментированы стратегии DS, WA, TG${plain}"
 
-  elif grep -q '443,1400,3478-3481,5349,50000-50099,19294-19344$' "/opt/zapret2/config"; then
-    sed -i 's/443,1400,3478-3481,5349,50000-50099,19294-19344$/443/' /opt/zapret2/config
-    sed -i 's/^--filter-udp=50000/--skip --filter-udp=50000/' "/opt/zapret2/config"
+  else
+    profile_lock_clear "VOICE_UDP"
+    config_ports_remove "$cfg" "NFQWS2_PORTS_UDP" "$voice_ports"
+    config_line_skip "$cfg" "--filter-udp=50000-50099,1400,3478-3481,5349,19294-19344"
 
     init_dir="$(dirname "$ZAPRET2_INIT")"
     custom_dir="$init_dir/custom.d"
@@ -90,10 +91,7 @@ menu_action_toggle_bolvan_ports() {
     curl -L -o "$custom_dir/50-discord-media" \
       https://raw.githubusercontent.com/bol-van/zapret2/master/init.d/custom.d.examples.linux/50-discord-media
 
-    echo -e "${green}Работа от скриптов bol-van. Вернули строку к виду NFQWS_PORTS_UDP=443 и добавили \"--skip \" в начале строк стратегии войса${plain}"
-  else
-    echo -e "${yellow}Неизвестное состояние строки NFQWS_PORTS_UDP. Проверь конфиг вручную.${plain}"
-    return 0
+    echo -e "${green}Работа от скриптов bol-van. Убрали voice-порты из NFQWS2_PORTS_UDP и добавили \"--skip \" в начале строк стратегии войса${plain}"
   fi
 
   "$ZAPRET2_INIT" restart
@@ -122,18 +120,18 @@ menu_action_toggle_fwtype() {
 }
 
 menu_action_toggle_udp_range() {
-  if grep -q '^NFQWS_PORTS_UDP=443' "/opt/zapret2/config"; then
-    sed -i 's/^NFQWS_PORTS_UDP=443/NFQWS_PORTS_UDP=1026-65531,443/' "/opt/zapret2/config"
+  if grep -q '^NFQWS2_PORTS_UDP=443' "/opt/zapret2/config"; then
+    sed -i 's/^NFQWS2_PORTS_UDP=443/NFQWS2_PORTS_UDP=1026-65531,443/' "/opt/zapret2/config"
     sed -i 's/^--skip --filter-udp=1026/--filter-udp=1026/' "/opt/zapret2/config"
     echo -e "${green}Стратегия UDP обхода активирована. Выделены порты 1026-65531${plain}"
 
-  elif grep -q '^NFQWS_PORTS_UDP=1026-65531,443' "/opt/zapret2/config"; then
-    sed -i 's/^NFQWS_PORTS_UDP=1026-65531,443/NFQWS_PORTS_UDP=443/' "/opt/zapret2/config"
+  elif grep -q '^NFQWS2_PORTS_UDP=1026-65531,443' "/opt/zapret2/config"; then
+    sed -i 's/^NFQWS2_PORTS_UDP=1026-65531,443/NFQWS2_PORTS_UDP=443/' "/opt/zapret2/config"
     sed -i 's/^--filter-udp=1026/--skip --filter-udp=1026/' "/opt/zapret2/config"
     echo -e "${green}Стратегия UDP обхода ДЕактивирована. Выделенные порты 1026-65531 убраны${plain}"
 
   else
-    echo -e "${yellow}Неизвестное состояние строки NFQWS_PORTS_UDP. Проверь конфиг вручную.${plain}"
+    echo -e "${yellow}Неизвестное состояние строки NFQWS2_PORTS_UDP. Проверь конфиг вручную.${plain}"
     return 0
   fi
 

--- a/lib/config_mutation.sh
+++ b/lib/config_mutation.sh
@@ -1,0 +1,286 @@
+# Low-level config and custom.d mutations used by profile locks.
+
+z2r_root_dir() {
+  echo "${Z2R_ROOT:-/opt/zapret2}"
+}
+
+z2r_config_file() {
+  echo "${Z2R_CONFIG:-$(z2r_root_dir)/config}"
+}
+
+config_line_skip() {
+  local cfg="$1"
+  local pattern="$2"
+
+  [ -f "$cfg" ] || return 0
+  local tmp="${cfg}.tmp.$$"
+
+  awk -v p="$pattern" '
+    index($0, p) > 0 {
+      match($0, /^[[:space:]]*/)
+      pre = substr($0, 1, RLENGTH)
+      rest = substr($0, RLENGTH + 1)
+      if (rest !~ /^--skip[[:space:]]+/) {
+        $0 = pre "--skip " rest
+      }
+    }
+    { print }
+  ' "$cfg" > "$tmp" || {
+    rm -f "$tmp"
+    return 1
+  }
+
+  if cmp -s "$cfg" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$cfg"
+  fi
+}
+
+config_line_unskip() {
+  local cfg="$1"
+  local pattern="$2"
+
+  [ -f "$cfg" ] || return 0
+  local tmp="${cfg}.tmp.$$"
+
+  awk -v p="$pattern" '
+    index($0, p) > 0 {
+      match($0, /^[[:space:]]*/)
+      pre = substr($0, 1, RLENGTH)
+      rest = substr($0, RLENGTH + 1)
+      if (rest ~ /^--skip[[:space:]]+/) {
+        sub(/^--skip[[:space:]]+/, "", rest)
+        $0 = pre rest
+      }
+    }
+    { print }
+  ' "$cfg" > "$tmp" || {
+    rm -f "$tmp"
+    return 1
+  }
+
+  if cmp -s "$cfg" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$cfg"
+  fi
+}
+
+config_tcp_hostlist_remove() {
+  local cfg="$1"
+  local hostlist="$2"
+  local tmp
+
+  [ -f "$cfg" ] || return 0
+  tmp="${cfg}.tmp.$$"
+
+  awk -v hostlist="$hostlist" '
+    function append_field(value) {
+      out = out (out == "" ? "" : " ") value
+    }
+    index($0, "--qnum 300") > 0 && index($0, "--filter-tcp=80,443") > 0 {
+      match($0, /^[[:space:]]*/)
+      pre = substr($0, 1, RLENGTH)
+      rest = substr($0, RLENGTH + 1)
+      n = split(rest, fields, /[[:space:]]+/)
+      out = ""
+      hostlists = 0
+      skipped = 0
+      for (i = 1; i <= n; i++) {
+        if (fields[i] == "") continue
+        if (fields[i] == "--hostlist=" hostlist) continue
+        if (fields[i] ~ /^--hostlist=/) hostlists++
+        if (fields[i] == "--skip") skipped = 1
+        append_field(fields[i])
+      }
+      if (hostlists == 0 && skipped == 0) {
+        out = "--skip " out
+      }
+      $0 = pre out
+    }
+    { print }
+  ' "$cfg" > "$tmp" || {
+    rm -f "$tmp"
+    return 1
+  }
+
+  if cmp -s "$cfg" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$cfg"
+  fi
+}
+
+config_tcp_hostlist_add() {
+  local cfg="$1"
+  local hostlist="$2"
+  local tmp
+
+  [ -f "$cfg" ] || return 0
+  tmp="${cfg}.tmp.$$"
+
+  awk -v hostlist="$hostlist" '
+    function append_field(value) {
+      out = out (out == "" ? "" : " ") value
+    }
+    index($0, "--qnum 300") > 0 && index($0, "--filter-tcp=80,443") > 0 {
+      match($0, /^[[:space:]]*/)
+      pre = substr($0, 1, RLENGTH)
+      rest = substr($0, RLENGTH + 1)
+      n = split(rest, fields, /[[:space:]]+/)
+      out = ""
+      seen = 0
+      inserted = 0
+      for (i = 1; i <= n; i++) {
+        if (fields[i] == "--hostlist=" hostlist) seen = 1
+      }
+      for (i = 1; i <= n; i++) {
+        if (fields[i] == "" || fields[i] == "--skip") continue
+        if (seen == 0 && inserted == 0 && fields[i] ~ /^--in-range=/) {
+          append_field("--hostlist=" hostlist)
+          inserted = 1
+        }
+        append_field(fields[i])
+      }
+      if (seen == 0 && inserted == 0) {
+        append_field("--hostlist=" hostlist)
+      }
+      $0 = pre out
+    }
+    { print }
+  ' "$cfg" > "$tmp" || {
+    rm -f "$tmp"
+    return 1
+  }
+
+  if cmp -s "$cfg" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$cfg"
+  fi
+}
+
+config_get_var() {
+  local cfg="$1"
+  local var="$2"
+
+  sed -n "s/^${var}=//p" "$cfg" 2>/dev/null | head -n1
+}
+
+config_set_var() {
+  local cfg="$1"
+  local var="$2"
+  local value="$3"
+  local old tmp
+
+  [ -f "$cfg" ] || return 0
+  old="$(config_get_var "$cfg" "$var")"
+  [ "$old" = "$value" ] && return 0
+
+  tmp="${cfg}.tmp.$$"
+  awk -v var="$var" -v value="$value" '
+    $0 ~ "^" var "=" && done == 0 {
+      print var "=" value
+      done = 1
+      next
+    }
+    { print }
+  ' "$cfg" > "$tmp" || {
+    rm -f "$tmp"
+    return 1
+  }
+
+  if cmp -s "$cfg" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$cfg"
+  fi
+}
+
+config_ports_remove() {
+  local cfg="$1"
+  local var="$2"
+  local remove_csv="$3"
+  local value result port remove keep
+
+  value="$(config_get_var "$cfg" "$var")"
+  [ -z "$value" ] && return 0
+
+  result=""
+  IFS=',' read -ra current_ports <<< "$value"
+  IFS=',' read -ra remove_ports <<< "$remove_csv"
+  for port in "${current_ports[@]}"; do
+    [ -z "$port" ] && continue
+    keep=1
+    for remove in "${remove_ports[@]}"; do
+      if [ "$port" = "$remove" ]; then
+        keep=0
+        break
+      fi
+    done
+    [ "$keep" -eq 1 ] && result="${result:+$result,}$port"
+  done
+
+  config_set_var "$cfg" "$var" "$result"
+}
+
+config_ports_add() {
+  local cfg="$1"
+  local var="$2"
+  local add_csv="$3"
+  local value result port add found
+
+  value="$(config_get_var "$cfg" "$var")"
+  result="$value"
+
+  IFS=',' read -ra add_ports <<< "$add_csv"
+  for add in "${add_ports[@]}"; do
+    [ -z "$add" ] && continue
+    found=0
+    IFS=',' read -ra current_ports <<< "$result"
+    for port in "${current_ports[@]}"; do
+      if [ "$port" = "$add" ]; then
+        found=1
+        break
+      fi
+    done
+    [ "$found" -eq 0 ] && result="${result:+$result,}$add"
+  done
+
+  config_set_var "$cfg" "$var" "$result"
+}
+
+custom_script_dir() {
+  if [ -n "${ZAPRET2_INIT:-}" ]; then
+    echo "$(dirname "$ZAPRET2_INIT")/custom.d"
+  else
+    echo "$(z2r_root_dir)/init.d/sysv/custom.d"
+  fi
+}
+
+custom_script_disable() {
+  local script_name="$1"
+  local custom_dir disabled_dir
+
+  custom_dir="$(custom_script_dir)"
+  disabled_dir="${custom_dir}.disabled"
+
+  if [ -f "$custom_dir/$script_name" ]; then
+    mkdir -p "$disabled_dir"
+    mv -f "$custom_dir/$script_name" "$disabled_dir/$script_name"
+  fi
+}
+
+custom_script_enable() {
+  local script_name="$1"
+  local custom_dir disabled_dir
+
+  custom_dir="$(custom_script_dir)"
+  disabled_dir="${custom_dir}.disabled"
+
+  if [ -f "$disabled_dir/$script_name" ]; then
+    mkdir -p "$custom_dir"
+    mv -f "$disabled_dir/$script_name" "$custom_dir/$script_name"
+  fi
+}

--- a/lib/profile_lock.sh
+++ b/lib/profile_lock.sh
@@ -1,0 +1,391 @@
+# Persistent profile lock state.
+# Missing row means auto/current behavior. Stored values are "skip" or N.
+
+profile_lock_file() {
+  echo "${Z2R_PROFILE_STATE_FILE:-/opt/etc/z2r/profile.lock}"
+}
+
+profile_lock_get() {
+  local profile="$1"
+  local file
+  file="$(profile_lock_file)"
+
+  if [ ! -f "$file" ]; then
+    echo "auto"
+    return 0
+  fi
+
+  awk -v p="$profile" '
+    /^[[:space:]]*#/ || NF == 0 { next }
+    $1 == p { print $2; found = 1; exit }
+    END { if (!found) print "auto" }
+  ' "$file"
+}
+
+profile_lock_set() {
+  local profile="$1"
+  local state="$2"
+  local current file dir tmp max
+
+  [ "$state" = "0" ] && state="skip"
+
+  case "$state" in
+    ""|"auto")
+      profile_lock_clear "$profile"
+      return
+      ;;
+    "skip")
+      ;;
+    *)
+      if ! echo "$state" | grep -Eq '^[1-9][0-9]*$'; then
+        echo "Некорректное состояние профиля: $state"
+        return 1
+      fi
+      max="$(profile_strategy_max "$profile" 2>/dev/null || true)"
+      if [ -z "$max" ] || [ "$state" -gt "$max" ]; then
+        echo "Стратегия $state вне диапазона для $profile"
+        return 1
+      fi
+      ;;
+  esac
+
+  current="$(profile_lock_get "$profile")"
+  [ "$current" = "$state" ] && return 0
+
+  file="$(profile_lock_file)"
+  dir="${file%/*}"
+  tmp="${file}.tmp.$$"
+
+  mkdir -p "$dir"
+  if [ -f "$file" ]; then
+    awk -v p="$profile" '
+      BEGIN { OFS = "\t" }
+      /^[[:space:]]*#/ || NF == 0 { print; next }
+      $1 != p { print }
+    ' "$file" > "$tmp" || {
+      rm -f "$tmp"
+      return 1
+    }
+  else
+    : > "$tmp"
+  fi
+
+  printf '%s\t%s\n' "$profile" "$state" >> "$tmp"
+
+  if [ -f "$file" ] && cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$file"
+  fi
+}
+
+profile_lock_clear() {
+  local profile="$1"
+  local current file dir tmp
+
+  current="$(profile_lock_get "$profile")"
+  [ "$current" = "auto" ] && return 0
+
+  file="$(profile_lock_file)"
+  dir="${file%/*}"
+  tmp="${file}.tmp.$$"
+
+  mkdir -p "$dir"
+  if [ -f "$file" ]; then
+    awk -v p="$profile" '
+      BEGIN { OFS = "\t" }
+      /^[[:space:]]*#/ || NF == 0 { print; next }
+      $1 != p { print }
+    ' "$file" > "$tmp" || {
+      rm -f "$tmp"
+      return 1
+    }
+  else
+    : > "$tmp"
+  fi
+
+  if [ -f "$file" ] && cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$file"
+  fi
+}
+
+profile_strategy_base() {
+  local root
+  root="$(z2r_root_dir)"
+
+  case "$1" in
+    "YT_UDP") echo "$root/extra_strats/UDP/YT" ;;
+    "YT_TCP") echo "$root/extra_strats/TCP/YT" ;;
+    "YT_GV")  echo "$root/extra_strats/TCP/GV" ;;
+    "RKN")    echo "$root/extra_strats/TCP/RKN" ;;
+    *)        return 1 ;;
+  esac
+}
+
+profile_strategy_max() {
+  case "$1" in
+    "YT_UDP") echo "8" ;;
+    "YT_TCP"|"YT_GV"|"RKN") echo "17" ;;
+    *) return 1 ;;
+  esac
+}
+
+profile_strategy_list_file() {
+  local profile="$1"
+  local root nested flat
+  root="$(z2r_root_dir)"
+
+  case "$profile" in
+    "YT_UDP")
+      nested="$root/extra_strats/UDP/YT/List.txt"
+      flat="$root/extra_strats/UDP_YT_list.txt"
+      ;;
+    "YT_TCP")
+      nested="$root/extra_strats/TCP/YT/List.txt"
+      flat="$root/extra_strats/TCP_YT_list.txt"
+      ;;
+    "RKN")
+      nested="$root/extra_strats/TCP/RKN/List.txt"
+      flat="$root/extra_strats/TCP_RKN_list.txt"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  if [ -s "$nested" ]; then
+    echo "$nested"
+  else
+    echo "$flat"
+  fi
+}
+
+profile_can_skip() {
+  case "$1" in
+    "YT_UDP"|"YT_TCP"|"RKN"|"VOICE_UDP") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+profile_write_if_changed() {
+  local dest="$1"
+  local content="$2"
+  local tmp
+
+  mkdir -p "$(dirname "$dest")"
+  tmp="${dest}.tmp.$$"
+  printf '%s\n' "$content" > "$tmp"
+
+  if [ -f "$dest" ] && cmp -s "$dest" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$dest"
+  fi
+}
+
+profile_clear_strategy_files() {
+  local profile="$1"
+  local base max i file
+
+  base="$(profile_strategy_base "$profile")" || return 0
+  max="$(profile_strategy_max "$profile")" || return 0
+
+  mkdir -p "$base"
+  for ((i=1; i<=max; i++)); do
+    file="$base/$i.txt"
+    [ -s "$file" ] && : > "$file"
+  done
+
+  return 0
+}
+
+profile_apply_strategy_num() {
+  local profile="$1"
+  local strat_num="$2"
+  local base max list_file i
+
+  base="$(profile_strategy_base "$profile")" || return 0
+  max="$(profile_strategy_max "$profile")" || return 0
+
+  if [ "$strat_num" -lt 1 ] || [ "$strat_num" -gt "$max" ]; then
+    echo "Стратегия $strat_num вне диапазона для $profile"
+    return 1
+  fi
+
+  mkdir -p "$base"
+  for ((i=1; i<=max; i++)); do
+    if [ "$i" -eq "$strat_num" ]; then
+      case "$profile" in
+        "YT_GV")
+          profile_write_if_changed "$base/$i.txt" "googlevideo.com"
+          ;;
+        *)
+          list_file="$(profile_strategy_list_file "$profile")"
+          if [ -s "$list_file" ]; then
+            if [ ! -f "$base/$i.txt" ] || ! cmp -s "$list_file" "$base/$i.txt"; then
+              cp -f "$list_file" "$base/$i.txt"
+            fi
+          fi
+          ;;
+      esac
+    else
+      [ -s "$base/$i.txt" ] && : > "$base/$i.txt"
+    fi
+  done
+
+  return 0
+}
+
+profile_apply_yt_udp_skip() {
+  local cfg="$1"
+  local root
+  root="$(z2r_root_dir)"
+
+  profile_clear_strategy_files "YT_UDP"
+  config_line_skip "$cfg" "--filter-udp=443 --hostlist=$root/extra_strats/UDP_YT_list.txt"
+}
+
+profile_apply_yt_udp_enable() {
+  local cfg="$1"
+  local root
+  root="$(z2r_root_dir)"
+
+  config_line_unskip "$cfg" "--filter-udp=443 --hostlist=$root/extra_strats/UDP_YT_list.txt"
+}
+
+profile_apply_yt_tcp_skip() {
+  local cfg="$1"
+  local root
+  root="$(z2r_root_dir)"
+
+  profile_clear_strategy_files "YT_TCP"
+  config_tcp_hostlist_remove "$cfg" "$root/extra_strats/TCP_YT_list.txt"
+}
+
+profile_apply_yt_tcp_enable() {
+  local cfg="$1"
+  local root
+  root="$(z2r_root_dir)"
+
+  config_tcp_hostlist_add "$cfg" "$root/extra_strats/TCP_YT_list.txt"
+}
+
+profile_apply_rkn_skip() {
+  local cfg="$1"
+  local root
+  root="$(z2r_root_dir)"
+
+  profile_clear_strategy_files "RKN"
+  config_tcp_hostlist_remove "$cfg" "$root/extra_strats/TCP_RKN_list.txt"
+}
+
+profile_apply_rkn_enable() {
+  local cfg="$1"
+  local root
+  root="$(z2r_root_dir)"
+
+  config_tcp_hostlist_add "$cfg" "$root/extra_strats/TCP_RKN_list.txt"
+}
+
+profile_apply_voice_skip() {
+  local cfg="$1"
+  local voice_ports="50000-50099,1400,3478-3481,5349,19294-19344"
+
+  config_line_skip "$cfg" "--filter-udp=50000-50099,1400,3478-3481,5349,19294-19344"
+  config_ports_remove "$cfg" "NFQWS2_PORTS_UDP" "$voice_ports"
+  custom_script_disable "50-stun4all"
+  custom_script_disable "50-discord-media"
+}
+
+profile_apply_voice_auto() {
+  local cfg="$1"
+  local voice_ports="50000-50099,1400,3478-3481,5349,19294-19344"
+
+  config_ports_remove "$cfg" "NFQWS2_PORTS_UDP" "$voice_ports"
+  config_line_unskip "$cfg" "--filter-udp=50000-50099,1400,3478-3481,5349,19294-19344"
+  custom_script_enable "50-stun4all"
+  custom_script_enable "50-discord-media"
+}
+
+profile_apply_voice_classic() {
+  local cfg="$1"
+  local voice_ports="1400,3478-3481,5349,50000-50099,19294-19344"
+
+  config_ports_add "$cfg" "NFQWS2_PORTS_UDP" "$voice_ports"
+  config_line_unskip "$cfg" "--filter-udp=50000-50099,1400,3478-3481,5349,19294-19344"
+  custom_script_disable "50-stun4all"
+  custom_script_disable "50-discord-media"
+}
+
+profile_apply_skip() {
+  local profile="$1"
+  local cfg="$2"
+
+  if ! profile_can_skip "$profile"; then
+    echo "Профиль $profile пока нельзя безопасно отключить через --skip."
+    return 0
+  fi
+
+  case "$profile" in
+    "YT_UDP")    profile_apply_yt_udp_skip "$cfg" ;;
+    "YT_TCP")    profile_apply_yt_tcp_skip "$cfg" ;;
+    "RKN")       profile_apply_rkn_skip "$cfg" ;;
+    "VOICE_UDP") profile_apply_voice_skip "$cfg" ;;
+  esac
+}
+
+profile_apply_enable() {
+  local profile="$1"
+  local cfg="$2"
+
+  case "$profile" in
+    "YT_UDP")    profile_apply_yt_udp_enable "$cfg" ;;
+    "YT_TCP")    profile_apply_yt_tcp_enable "$cfg" ;;
+    "RKN")       profile_apply_rkn_enable "$cfg" ;;
+    "VOICE_UDP") profile_apply_voice_classic "$cfg" ;;
+  esac
+}
+
+profile_apply_one() {
+  local profile="$1"
+  local state="${2:-$(profile_lock_get "$profile")}"
+  local cfg="${3:-$(z2r_config_file)}"
+  local max
+
+  case "$state" in
+    "auto"|"")
+      return 0
+      ;;
+    "skip")
+      profile_apply_skip "$profile" "$cfg"
+      ;;
+    *)
+      if echo "$state" | grep -Eq '^[1-9][0-9]*$'; then
+        max="$(profile_strategy_max "$profile" 2>/dev/null || true)"
+        if [ -z "$max" ] || [ "$state" -gt "$max" ]; then
+          echo "Пропуск profile lock: $profile=$state вне диапазона."
+          return 0
+        fi
+        profile_apply_enable "$profile" "$cfg"
+        profile_apply_strategy_num "$profile" "$state"
+      fi
+      ;;
+  esac
+}
+
+profile_apply_all() {
+  local cfg="${1:-$(z2r_config_file)}"
+  local file profile state
+
+  file="$(profile_lock_file)"
+  [ -f "$file" ] || return 0
+
+  while read -r profile state _; do
+    case "$profile" in
+      ""|\#*) continue ;;
+    esac
+    profile_apply_one "$profile" "$state" "$cfg"
+  done < "$file"
+}

--- a/lib/strategies.sh
+++ b/lib/strategies.sh
@@ -19,22 +19,55 @@ get_active_strat_num() {
 
 # Функция для генерации строки статуса стратегий
 get_current_strategies_info() {
-    local s_udp=$(get_active_strat_num "/opt/zapret2/extra_strats/UDP/YT" 8)
-    local s_tcp=$(get_active_strat_num "/opt/zapret2/extra_strats/TCP/YT" 17)
-    local s_gv=$(get_active_strat_num "/opt/zapret2/extra_strats/TCP/GV" 17)
-    local s_rkn=$(get_active_strat_num "/opt/zapret2/extra_strats/TCP/RKN" 17)
-    
-    # Формируем красивую строку. Цвета можно менять.
-    # Функция для окраски: 0 - серый, >0 - зеленый
-    colorize_num() {
-        if [ "$1" == "0" ]; then
-            echo "${gray}Def${plain}"
+    local s_udp s_tcp s_gv s_rkn s_voice
+
+    profile_status_value() {
+        local profile="$1"
+        local folder="$2"
+        local max="$3"
+        local state active
+
+        state="$(profile_lock_get "$profile")"
+        case "$state" in
+          "skip")
+            echo "0"
+            return
+            ;;
+          "auto"|"")
+            ;;
+          *)
+            if echo "$state" | grep -Eq '^[1-9][0-9]*$'; then
+              echo "$state"
+              return
+            fi
+            ;;
+        esac
+
+        active="$(get_active_strat_num "$folder" "$max")"
+        if [ "$active" = "0" ]; then
+          echo "auto"
         else
-            echo "${green}$1${plain}"
+          echo "$active"
         fi
     }
 
-    echo -e "YT_UDP:$(colorize_num "$s_udp") YT_TCP:$(colorize_num "$s_tcp") YT_GV:$(colorize_num "$s_gv") RKN:$(colorize_num "$s_rkn")"
+    colorize_state() {
+        case "$1" in
+          "auto") echo "${yellow}auto${plain}" ;;
+          "0")    echo "${red}0${plain}" ;;
+          *)      echo "${green}$1${plain}" ;;
+        esac
+    }
+
+    s_udp="$(profile_status_value "YT_UDP" "$(profile_strategy_base YT_UDP)" 8)"
+    s_tcp="$(profile_status_value "YT_TCP" "$(profile_strategy_base YT_TCP)" 17)"
+    s_gv="$(profile_status_value "YT_GV" "$(profile_strategy_base YT_GV)" 17)"
+    s_rkn="$(profile_status_value "RKN" "$(profile_strategy_base RKN)" 17)"
+    s_voice="$(profile_lock_get "VOICE_UDP")"
+    [ "$s_voice" = "skip" ] && s_voice="0"
+    [ -z "$s_voice" ] && s_voice="auto"
+
+    echo -e "YT_UDP=$(colorize_state "$s_udp") YT_TCP=$(colorize_state "$s_tcp") YT_GV=$(colorize_state "$s_gv") RKN=$(colorize_state "$s_rkn") VOICE_UDP=$(colorize_state "$s_voice")"
 }
 
 #Функция для функции подбора стратегий
@@ -43,16 +76,39 @@ try_strategies() {
     local base_path="$2"
     local list_file="$3"
     local final_action="$4"
+    local profile_name="$5"
+    local strat_num answer_strat
     
-    read -re -p "Введите номер стратегии к которой перейти или Enter: " strat_num
-    if (( strat_num < 1 || strat_num > count )); then
+    read -re -p "Введите номер стратегии (0 - отключить профиль, Enter - без изменений): " strat_num
+    if [[ -z "$strat_num" ]]; then
+        echo "Без изменений."
+        return
+    fi
+
+    if [[ "$strat_num" == "0" ]]; then
+        if [[ -n "$profile_name" ]] && profile_can_skip "$profile_name"; then
+            profile_lock_set "$profile_name" "skip"
+            profile_apply_one "$profile_name" "skip"
+            if [[ -n "${ZAPRET2_INIT:-}" && -f "$ZAPRET2_INIT" ]]; then
+              "$ZAPRET2_INIT" restart || true
+            fi
+            echo "Профиль $profile_name отключён и сохранён как 0."
+        else
+            echo "Этот профиль пока нельзя безопасно отключить через 0."
+        fi
+        return
+    fi
+
+    if ! echo "$strat_num" | grep -Eq '^[0-9]+$' || (( strat_num < 1 || strat_num > count )); then
         echo "Введено значение не из диапазона. Начинаем с 1 стратегии"
         strat_num=1
     fi
 
+    mkdir -p "$base_path"
+
     # Предварительная очистка всех файлов стратегий в папке
     for ((clr_txt=1; clr_txt<=count; clr_txt++)); do
-        echo -n > "$base_path/${clr_txt}.txt"
+        [ -s "$base_path/${clr_txt}.txt" ] && echo -n > "$base_path/${clr_txt}.txt"
     done
 
     # Основной цикл перебора
@@ -61,16 +117,22 @@ try_strategies() {
         # Очищаем файл предыдущей стратегии (чтобы не было дублей)
         if [[ $strat_num -ge 2 ]]; then
             prev=$((strat_num - 1))
-            echo -n > "$base_path/${prev}.txt"
+            [ -s "$base_path/${prev}.txt" ] && echo -n > "$base_path/${prev}.txt"
         fi
 
         # Запись в файл текущей стратегии
         if [[ "$list_file" != "/dev/null" ]]; then
             # Режим списка (копируем весь файл)
-            cp "$list_file" "$base_path/${strat_num}.txt"
+            if [ ! -s "$list_file" ]; then
+              echo "Не найден список доменов: $list_file"
+              return 1
+            fi
+            if [ ! -f "$base_path/${strat_num}.txt" ] || ! cmp -s "$list_file" "$base_path/${strat_num}.txt"; then
+              cp "$list_file" "$base_path/${strat_num}.txt"
+            fi
         else
             # Режим одного домена
-            echo "$user_domain" > "$base_path/${strat_num}.txt"
+            profile_write_if_changed "$base_path/${strat_num}.txt" "$user_domain"
         fi
         
         echo "Стратегия номер $strat_num активирована"
@@ -104,6 +166,13 @@ try_strategies() {
         
         if [[ "$answer_strat" == "1" ]]; then
             echo "Стратегия $strat_num сохранена."
+            if [[ -n "$profile_name" ]]; then
+              profile_lock_set "$profile_name" "$strat_num"
+              profile_apply_one "$profile_name" "$strat_num"
+              if [[ -n "${ZAPRET2_INIT:-}" && -f "$ZAPRET2_INIT" ]]; then
+                "$ZAPRET2_INIT" restart || true
+              fi
+            fi
             send_stats  # Отправка телеметрии (если включена)
             
             # Если передано дополнительное действие (final_action), выполняем его
@@ -114,14 +183,14 @@ try_strategies() {
             
         elif [[ "$answer_strat" == "0" ]]; then
             # Сброс текущей стратегии при отмене
-            echo -n > "$base_path/${strat_num}.txt"
+            [ -s "$base_path/${strat_num}.txt" ] && echo -n > "$base_path/${strat_num}.txt"
             echo "Изменения отменены."
             return
         fi
     done
 
     # Если цикл закончился, а пользователь ничего не выбрал
-    echo -n > "$base_path/${count}.txt"
+    [ -s "$base_path/${count}.txt" ] && echo -n > "$base_path/${count}.txt"
     echo "Все стратегии испробованы. Ничего не подошло."
     pause_enter
     return
@@ -154,13 +223,13 @@ Strats_Tryer() {
       echo "Подбор для хост-листа YouTube с видеопотоком (UDP QUIC - браузеры, моб. приложения). Ранее заданная стратегия этого листа сброшена в дефолт."
       #вывод подсказки
       show_hint "UDP"
-      try_strategies 8 "/opt/zapret2/extra_strats/UDP/YT" "/opt/zapret2/extra_strats/UDP/YT/List.txt" ""
+      try_strategies 8 "$(profile_strategy_base YT_UDP)" "$(profile_strategy_list_file YT_UDP)" "" "YT_UDP"
       ;;
     "2")
       echo "Подбор для хост-листа YouTube (TCP - сам интерфейс. Без видео-домена). Ранее заданная стратегия этого листа сброшена в дефолт."
       #вывод подсказки
       show_hint "TCP"
-      try_strategies 17 "/opt/zapret2/extra_strats/TCP/YT" "/opt/zapret2/extra_strats/TCP/YT/List.txt" ""
+      try_strategies 17 "$(profile_strategy_base YT_TCP)" "$(profile_strategy_list_file YT_TCP)" "" "YT_TCP"
       ;;
     "3")
       echo "Подбор для googlevideo.com (Видеопоток YouTube). Ранее заданная стратегия этого листа сброшена в дефолт."
@@ -170,17 +239,15 @@ Strats_Tryer() {
       user_domain="googlevideo.com"
       #вывод подсказки
       show_hint "GV"
-      try_strategies 17 "/opt/zapret2/extra_strats/TCP/GV" "/dev/null" ""
+      try_strategies 17 "$(profile_strategy_base YT_GV)" "/dev/null" "" "YT_GV"
       ;;
     "4")
       echo "Подбор для хост-листа основных доменов блока RKN. Проверка доступности задана на домен meduza.io. Ранее заданная стратегия этого листа сброшена в дефолт."
-      for numRKN in {1..17}; do
-        echo -n > "/opt/zapret2/extra_strats/TCP/RKN/${numRKN}.txt"
-      done
+      profile_clear_strategy_files "RKN"
       user_domain="meduza.io"
       #вывод подсказки
       show_hint "RKN"
-      try_strategies 17 "/opt/zapret2/extra_strats/TCP/RKN" "/opt/zapret2/extra_strats/TCP/RKN/List.txt" ""
+      try_strategies 17 "$(profile_strategy_base RKN)" "$(profile_strategy_list_file RKN)" "" "RKN"
       ;;
     "5")
       echo "Режим ручного указания домена"

--- a/lib/submenus.sh
+++ b/lib/submenus.sh
@@ -18,6 +18,7 @@ strategies_submenu() {
     submenu_item "	3" "YouTube (TCP. Видеопоток/GV домен)." "17 вариантов"
     submenu_item "	4" "RKN (Популярные блокированные сайты. Дискорд в т.ч.)." "17 вариантов"
     submenu_item "	5" "Отдельный домен." "17 вариантов"
+    submenu_item "	6" "Discord/voice UDP профиль." "0 - выключить, 1 - auto"
     submenu_item "	0" "Назад"
     echo ""
 
@@ -35,6 +36,10 @@ strategies_submenu() {
         Strats_Tryer "$user_domain"
         pause_enter
         ;;
+      "6")
+        voice_profile_submenu
+        pause_enter
+        ;;
       "0"|"")
         return
         ;;
@@ -44,6 +49,50 @@ strategies_submenu() {
         ;;
     esac
   done
+}
+
+voice_profile_submenu() {
+  local state display ans
+
+  state="$(profile_lock_get "VOICE_UDP")"
+  display="$state"
+  [ "$display" = "skip" ] && display="0"
+  [ -z "$display" ] && display="auto"
+
+  echo -e "${cyan}--- Discord/voice UDP профиль ---${plain}"
+  echo -e "Текущее состояние: ${yellow}${display}${plain}"
+  echo ""
+  echo "0 - выключить профиль через --skip, убрать voice-порты и отключить custom.d scripts"
+  echo "1 - вернуть auto/default; для классических стратегий используйте пункт 8 главного меню"
+  echo "Enter - назад"
+  echo ""
+
+  read -re -p "Ваш выбор: " ans
+  case "$ans" in
+    "0")
+      profile_lock_set "VOICE_UDP" "skip"
+      profile_apply_one "VOICE_UDP" "skip"
+      if [[ -n "${ZAPRET2_INIT:-}" && -f "$ZAPRET2_INIT" ]]; then
+        "$ZAPRET2_INIT" restart || true
+      fi
+      echo -e "${green}VOICE_UDP сохранён как 0 и применён.${plain}"
+      ;;
+    "1")
+      profile_lock_clear "VOICE_UDP"
+      profile_apply_voice_auto "$(z2r_config_file)"
+      if [[ -n "${ZAPRET2_INIT:-}" && -f "$ZAPRET2_INIT" ]]; then
+        "$ZAPRET2_INIT" restart || true
+      fi
+      echo -e "${green}VOICE_UDP возвращён в auto/default.${plain}"
+      ;;
+    "")
+      return
+      ;;
+    *)
+      echo -e "${yellow}Неверный ввод.${plain}"
+      sleep 1
+      ;;
+  esac
 }
 
 flowoffload_submenu() {

--- a/tests/profile_lock_smoke.sh
+++ b/tests/profile_lock_smoke.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+
+  grep -q -- "$pattern" "$file" || fail "$message"
+}
+
+assert_text_contains() {
+  local text="$1"
+  local pattern="$2"
+  local message="$3"
+
+  echo "$text" | grep -q -- "$pattern" || fail "$message"
+}
+
+assert_text_not_contains() {
+  local text="$1"
+  local pattern="$2"
+  local message="$3"
+
+  ! echo "$text" | grep -q -- "$pattern" || fail "$message"
+}
+
+TMP_DIR="$(mktemp -d /tmp/z2r-profile-lock.XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+export Z2R_ROOT="$TMP_DIR/zapret2"
+export Z2R_CONFIG="$Z2R_ROOT/config"
+export Z2R_PROFILE_STATE_FILE="$TMP_DIR/profile.lock"
+
+mkdir -p "$Z2R_ROOT/extra_strats" "$Z2R_ROOT/init.d/sysv/custom.d"
+sed "s#/opt/zapret2#$Z2R_ROOT#g" "$REPO_DIR/config.default" > "$Z2R_CONFIG"
+
+printf 'youtube.com\n' > "$Z2R_ROOT/extra_strats/TCP_YT_list.txt"
+printf 'meduza.io\n' > "$Z2R_ROOT/extra_strats/TCP_RKN_list.txt"
+printf 'youtube.com\n' > "$Z2R_ROOT/extra_strats/UDP_YT_list.txt"
+printf 'script\n' > "$Z2R_ROOT/init.d/sysv/custom.d/50-stun4all"
+printf 'script\n' > "$Z2R_ROOT/init.d/sysv/custom.d/50-discord-media"
+discord_line_before="$(grep -- "discord.txt" "$Z2R_CONFIG" | head -n1)"
+
+# shellcheck source=/dev/null
+source "$REPO_DIR/lib/config_mutation.sh"
+# shellcheck source=/dev/null
+source "$REPO_DIR/lib/profile_lock.sh"
+
+bash -n \
+  "$REPO_DIR/z2r.sh" \
+  "$REPO_DIR/lib/config_mutation.sh" \
+  "$REPO_DIR/lib/profile_lock.sh" \
+  "$REPO_DIR/lib/strategies.sh" \
+  "$REPO_DIR/lib/submenus.sh" \
+  "$REPO_DIR/lib/actions.sh"
+
+[ "$(profile_lock_get YT_UDP)" = "auto" ] || fail "missing lock must be auto"
+
+profile_lock_set YT_UDP skip
+[ "$(profile_lock_get YT_UDP)" = "skip" ] || fail "YT_UDP skip was not stored"
+assert_file_contains "$Z2R_PROFILE_STATE_FILE" "^YT_UDP[[:space:]][[:space:]]*skip$" "YT_UDP skip row is missing"
+profile_apply_all "$Z2R_CONFIG"
+
+yt_udp_count="$(grep -c -- "--skip --filter-udp=443 --hostlist=$Z2R_ROOT/extra_strats/UDP_YT_list.txt" "$Z2R_CONFIG")"
+[ "$yt_udp_count" = "1" ] || fail "YT_UDP skip count is $yt_udp_count"
+
+sum_before="$(sha256sum "$Z2R_CONFIG" | cut -d' ' -f1)"
+profile_apply_all "$Z2R_CONFIG"
+sum_after="$(sha256sum "$Z2R_CONFIG" | cut -d' ' -f1)"
+[ "$sum_before" = "$sum_after" ] || fail "profile_apply_all is not idempotent"
+
+profile_lock_set RKN skip
+profile_apply_all "$Z2R_CONFIG"
+tcp_line="$(grep -- "--qnum 300 --filter-tcp=80,443" "$Z2R_CONFIG" | head -n1)"
+assert_text_contains "$tcp_line" "TCP_YT_list.txt" "YT hostlist was removed while skipping RKN"
+assert_text_not_contains "$tcp_line" "TCP_RKN_list.txt" "RKN hostlist is still present"
+
+profile_lock_set YT_TCP skip
+profile_apply_all "$Z2R_CONFIG"
+tcp_line="$(grep -- "--qnum 300 --filter-tcp=80,443" "$Z2R_CONFIG" | head -n1)"
+assert_text_contains "$tcp_line" "^--skip .*--filter-tcp" "TCP line is not skipped after all hostlists are removed"
+
+profile_lock_set RKN 2
+[ "$(profile_lock_get RKN)" = "2" ] || fail "RKN strategy lock was not stored"
+assert_file_contains "$Z2R_PROFILE_STATE_FILE" "^RKN[[:space:]][[:space:]]*2$" "RKN strategy row is missing"
+profile_apply_all "$Z2R_CONFIG"
+tcp_line="$(grep -- "--qnum 300 --filter-tcp=80,443" "$Z2R_CONFIG" | head -n1)"
+assert_text_contains "$tcp_line" "TCP_RKN_list.txt" "RKN hostlist was not restored"
+[ -s "$Z2R_ROOT/extra_strats/TCP/RKN/2.txt" ] || fail "RKN strategy file was not restored"
+
+discord_line="$(grep -- "discord.txt" "$Z2R_CONFIG" | head -n1)"
+assert_text_not_contains "$discord_line" "TCP_RKN_list.txt\\|TCP_YT_list.txt" "Discord line was polluted: $discord_line"
+[ "$discord_line" = "$discord_line_before" ] || fail "Discord line changed: $discord_line"
+
+profile_lock_set VOICE_UDP skip
+profile_apply_all "$Z2R_CONFIG"
+assert_file_contains "$Z2R_CONFIG" "--skip --filter-udp=50000-50099,1400,3478-3481,5349,19294-19344" "VOICE line was not skipped"
+voice_ports_line="$(grep "^NFQWS2_PORTS_UDP=" "$Z2R_CONFIG")"
+assert_text_not_contains "$voice_ports_line" "50000-50099" "VOICE ports are still present"
+[ -f "$Z2R_ROOT/init.d/sysv/custom.d.disabled/50-stun4all" ] || fail "50-stun4all was not disabled"
+[ -f "$Z2R_ROOT/init.d/sysv/custom.d.disabled/50-discord-media" ] || fail "50-discord-media was not disabled"
+
+profile_lock_clear VOICE_UDP
+[ "$(profile_lock_get VOICE_UDP)" = "auto" ] || fail "VOICE_UDP lock was not cleared"
+assert_text_not_contains "$(cat "$Z2R_PROFILE_STATE_FILE")" "^VOICE_UDP[[:space:]]" "VOICE_UDP row is still stored"
+profile_apply_voice_auto "$Z2R_CONFIG"
+assert_file_contains "$Z2R_CONFIG" "^--filter-udp=50000-50099,1400,3478-3481,5349,19294-19344" "VOICE line was not restored"
+[ -f "$Z2R_ROOT/init.d/sysv/custom.d/50-stun4all" ] || fail "50-stun4all was not restored"
+[ -f "$Z2R_ROOT/init.d/sysv/custom.d/50-discord-media" ] || fail "50-discord-media was not restored"
+
+printf 'YT_UDP\t99\n' > "$Z2R_PROFILE_STATE_FILE"
+profile_apply_all "$Z2R_CONFIG" >/dev/null
+
+echo "profile_lock smoke ok"

--- a/z2r.sh
+++ b/z2r.sh
@@ -36,7 +36,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
 # Проверяем наличие всех нужных lib-файлов, иначе запускаем внешний скрипт
 missing_libs=0
 LIB_DIR="$SCRIPT_DIR/zapret2/z2r_lib"
-for lib in ui.sh provider.sh telemetry.sh recommendations.sh netcheck.sh premium.sh strategies.sh submenus.sh actions.sh; do
+for lib in ui.sh provider.sh telemetry.sh recommendations.sh netcheck.sh premium.sh config_mutation.sh profile_lock.sh strategies.sh submenus.sh actions.sh; do
   if [ ! -f "$LIB_DIR/$lib" ]; then
     missing_libs=1
     break
@@ -81,6 +81,14 @@ source "$SCRIPT_DIR/zapret2/z2r_lib/netcheck.sh"
 # “Premium” пункты 777/999 и их вспомогательные эффекты (рандом, спиннер, титулы)
 # Функции: rand_from_list, spinner_for_seconds, premium_get_or_set_title, zefeer_premium_777, zefeer_space_999
 source "$SCRIPT_DIR/zapret2/z2r_lib/premium.sh" 
+
+# Низкоуровневые правки config/ports/custom.d для profile lock
+# Функции: config_line_skip, config_tcp_hostlist_add, config_ports_remove
+source "$SCRIPT_DIR/zapret2/z2r_lib/config_mutation.sh"
+
+# Persisted profile lock: auto/skip/N, применение skip после обновления config
+# Функции: profile_lock_get, profile_lock_set, profile_apply_one, profile_apply_all
+source "$SCRIPT_DIR/zapret2/z2r_lib/profile_lock.sh"
 
 # Логика стратегий: определение активной стратегии, статус строкой, перебор стратегий, быстрый подбор
 # Функции: get_active_strat_num, get_current_strategies_info, try_strategies, Strats_Tryer
@@ -462,9 +470,9 @@ Enter (без цифр) - переустановка/обновление zapret
 5. Обновить стратегии, сбросить листы подбора стратегий и исключений (есть бэкап)
 6. Исключить домен из zapret2 обработки
 7. Открыть в редакторе config (Установит nano редактор ~250kb)
-8. Преключатель скриптов bol-van обхода войсов DS,WA,TG на стандартные страты или возврат к скриптам. Сейчас: '"${plain}"'['"$(grep -Eq '^NFQWS_PORTS_UDP=.*443$' /opt/zapret2/config && echo "Скрипты" || (grep -Eq '443,1400,3478-3481,5349,50000-50099,19294-19344$' /opt/zapret2/config && echo "Классические стратегии" || echo "Незвестно"))"']'"${yellow}"'
+8. Преключатель скриптов bol-van обхода войсов DS,WA,TG на стандартные страты или возврат к скриптам. Сейчас: '"${plain}"'['"$(grep -Eq '^NFQWS2_PORTS_UDP=.*50000-50099' /opt/zapret2/config && echo "Классические стратегии" || echo "Скрипты/auto/выкл")"']'"${yellow}"'
 9. Переключатель zapret2 на nftables/iptables (На всё жать Enter). Актуально для OpenWRT 21+. Может помочь с войсами. Сейчас: '"${plain}"'['"$(grep -q '^FWTYPE=iptables$' /opt/zapret2/config && echo "iptables" || (grep -q '^FWTYPE=nftables$' /opt/zapret2/config && echo "nftables" || echo "Неизвестно"))"']'"${yellow}"'
-10. (Де)активировать обход UDP на 1026-65531 портах (BF6, Fifa и т.п.). Сейчас: '"${plain}"'['"$(grep -q '^NFQWS_PORTS_UDP=443' /opt/zapret2/config && echo "Выключен" || (grep -q '^NFQWS_PORTS_UDP=1026-65531,443' /opt/zapret2/config && echo "Включен" || echo "Неизвестно"))"']'"${yellow}"'
+10. (Де)активировать обход UDP на 1026-65531 портах (BF6, Fifa и т.п.). Сейчас: '"${plain}"'['"$(grep -q '^NFQWS2_PORTS_UDP=443' /opt/zapret2/config && echo "Выключен" || (grep -q '^NFQWS2_PORTS_UDP=1026-65531,443' /opt/zapret2/config && echo "Включен" || echo "Неизвестно"))"']'"${yellow}"'
 11. Управление аппаратным ускорением zapret2. Может увеличить скорость на роутере. Сейчас: '"${plain}"'['"$(grep '^FLOWOFFLOAD=' /opt/zapret2/config)"']'"${yellow}"'
 12. Меню (Де)Активации работы по всем доменам TCP-443 без хост-листов (не затрагивает youtube стратегии) (безразборный режим) Сейчас: '"${plain}"'['"$(num=$(sed -n '112,128p' /opt/zapret2/config | grep -n '^--filter-tcp=443 --hostlist-domains= --' | head -n1 | cut -d: -f1); [ -n "$num" ] && echo "$num" || echo "Отключен")"']'"${yellow}"'
 13. Активировать доступ в меню через браузер (~3мб места)
@@ -751,6 +759,10 @@ fi
 if [[ "$release" == "x-wrt" ]]; then
 	sed -i 's/kmod-nft-nat kmod-nft-offload/kmod-nft-nat/' /opt/zapret2/common/installer.sh
 fi
+
+# Сохраняем явные profile skip/N после полной переустановки:
+# install_easy.sh дальше возьмет уже поправленный config.default.
+profile_apply_all /opt/zapret2/config.default
 
 #Запуск установочных скриптов и перезагрузка
 install_zapret_reboot


### PR DESCRIPTION
## Что изменено

Добавлена поддержка сохраняемого состояния профилей для z2r:

- `auto` - нет явной фиксации, поведение как раньше;
- `0` - профиль явно выключен через persisted `skip`;
- `N` - профиль включён и закреплён на стратегии `N`.

Состояние хранится вне `/opt/zapret2`:

```text
/opt/etc/z2r/profile.lock
```

`auto` в файл не записывается. Отсутствие записи означает `auto`.

## Основные изменения

- Добавлен `lib/profile_lock.sh`:
  - чтение/запись `profile.lock`;
  - применение `skip`/`N` для профилей;
  - явные apply-функции для `YT_UDP`, `YT_TCP`, `RKN`, `VOICE_UDP`.

- Добавлен `lib/config_mutation.sh`:
  - низкоуровневые изменения `config`;
  - добавление/удаление `--skip`;
  - изменение TCP hostlist в основном `--qnum 300` блоке;
  - изменение `NFQWS2_PORTS_UDP`;
  - отключение/возврат voice scripts из `custom.d`.

- Статус стратегий теперь различает:
  - `auto` - нет lock;
  - `0` - explicit skip;
  - `N` - закреплённая стратегия.

- После пересоздания `config` из `config.default` вызывается `profile_apply_all`, поэтому сохранённые skip-состояния не теряются после reset/update.

- При full reinstall persisted state применяется к свежему `config.default` до запуска install flow.

## Ограничения и важная деталь

В текущем `config.default` TCP-профили `YT_TCP` и `RKN` находятся в одном общем TCP-блоке. Поэтому `RKN=0` и `YT_TCP=0` не ставят `--skip` на весь общий TCP-блок, чтобы не выключить соседний профиль.

Вместо этого отключение TCP-профиля реализовано через удаление конкретного `--hostlist` из основного `--qnum 300` TCP-блока.

## VOICE_UDP

Для `VOICE_UDP=0` выполняется не только `--skip`, но и дополнительная очистка:

- добавляется `--skip` к voice UDP блоку;
- voice-порты удаляются из `NFQWS2_PORTS_UDP`;
- `50-stun4all` и `50-discord-media` перемещаются из `custom.d` в `.disabled`.

## Тесты

Добавлен smoke-test:

```bash
bash tests/profile_lock_smoke.sh
```

Он работает только во временной директории `/tmp`, не трогает `/opt`, не запускает zapret2 и проверяет:

- storage `auto/skip/N/clear`;
- идемпотентность `profile_apply_all`;
- `YT_UDP`;
- `YT_TCP/RKN` hostlist-level skip;
- `VOICE_UDP`;
- отсутствие изменений в отдельной Discord TCP-строке;
- stale invalid lock вроде `YT_UDP 99`.

Также добавлен `CONTRIBUTING.md` с инструкцией запуска smoke-test.
